### PR TITLE
Upgrade base Python version to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - env: DJANGO=master
 
   include:
-    - python: 3.7
+    - python: 3.8
       env: TOXENV=black,flake8
 
     - python: 3.6

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install-local:
 	python setup.py sdist bdist_wheel
 	python -m pip install dist/django-graphql-auth-${v}.tar.gz
 
-p ?= 37
+p ?= 38
 d ?= 30
 
 test:

--- a/tox.ini
+++ b/tox.ini
@@ -35,14 +35,14 @@ commands =
     {posargs}
 
 [testenv:flake8]
-basepython=python3.7
+basepython=python3.8
 deps = -e.[dev]
 commands =
     flake8 graphql_auth
 
 
 [testenv:black]
-basepython = python3.7
+basepython = python3.8
 deps = -e.[dev]
 commands  =
     black --exclude "/migrations/" graphql_auth testproject setup.py quickstart tests --check


### PR DESCRIPTION
Python 3.8 got .2 release and in a stable state. No reason not to upgrade.