### PR TITLE
Replace RemovedInDjango40Warning ugettext with gettext

### DIFF
--- a/graphql_auth/constants.py
+++ b/graphql_auth/constants.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class Messages:

--- a/graphql_auth/exceptions.py
+++ b/graphql_auth/exceptions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class GraphQLAuthError(Exception):


### PR DESCRIPTION
Project is not supporting Python 2, so no need to support unicode functions.