### PR TITLE
Prevent global UserNode

### DIFF
--- a/graphql_auth/schema.py
+++ b/graphql_auth/schema.py
@@ -13,6 +13,7 @@ class UserNode(DjangoObjectType):
         filter_fields = app_settings.USER_NODE_FILTER_FIELDS
         exclude_fields = app_settings.USER_NODE_EXCLUDE_FIELDS
         interfaces = (graphene.relay.Node,)
+        skip_registry = True
 
     pk = graphene.Int()
     archived = graphene.Boolean()

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -1,10 +1,21 @@
 import graphene
-from graphene_django.filter.fields import DjangoFilterConnectionField
 import graphql_jwt
+from graphene_django.filter.fields import DjangoFilterConnectionField
 
-from graphql_auth.schema import UserQuery, MeQuery
-from graphql_auth import relay
-from graphql_auth import mutations
+from graphql_auth import mutations, relay
+from graphql_auth.schema import MeQuery, UserQuery
+
+from .types import UserType
+
+
+class PublicUserQuery(graphene.ObjectType):
+    public_user = graphene.Field(UserType)
+
+    def resolve_public_user(self, info):
+        user = info.context.user
+        if user.is_authenticated:
+            return user
+        return None
 
 
 class AuthMutation(graphene.ObjectType):
@@ -47,7 +58,7 @@ class AuthRelayMutation(graphene.ObjectType):
     send_secondary_email_activation = relay.SendSecondaryEmailActivation.Field()
 
 
-class Query(UserQuery, MeQuery, graphene.ObjectType):
+class Query(UserQuery, MeQuery, PublicUserQuery, graphene.ObjectType):
     pass
 
 

--- a/tests/testCases.py
+++ b/tests/testCases.py
@@ -1,16 +1,15 @@
-import re
 import pprint
+import re
 
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
 from graphene.test import Client
 from graphene.types.schema import Schema
-from django.test import TestCase, RequestFactory
-from django.contrib.auth.models import AnonymousUser
-from django.contrib.auth import get_user_model
-
-
-from .schema import relay_schema, default_schema
 
 from graphql_auth.models import UserStatus
+
+from .schema import default_schema, relay_schema
 
 
 class TestBase(TestCase):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -54,3 +54,14 @@ class QueryTestCase(DefaultTestCase):
         """
         executed = self.make_request(query)
         self.assertIsNone(executed)
+
+    def test_public_user_query(self):
+        query = """
+        query {
+            publicUser {
+                verified
+            }
+        }
+        """
+        executed = self.make_request(query, variables={"user": self.user1})
+        self.assertEqual(executed, {"verified": False})

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,0 +1,19 @@
+import graphene
+from django.contrib.auth import get_user_model
+from graphene_django.types import DjangoObjectType
+
+
+class UserType(DjangoObjectType):
+    class Meta:
+        model = get_user_model()
+        interfaces = (graphene.relay.Node,)
+        skip_registry = True
+
+    pk = graphene.Int()
+    verified = graphene.Boolean()
+
+    def resolve_pk(self, info):
+        return self.pk
+
+    def resolve_verified(self, info):
+        return self.status.verified


### PR DESCRIPTION
Prevents that `UserNode` is registered globally for the `User` type.

If someone really wants to use `UserNode`, they can just declare an explicit field `user = graphene.Field(UserNode)` like the default queries.

