### PR TITLE
Use Exclude field

### DIFF
--- a/graphql_auth/schema.py
+++ b/graphql_auth/schema.py
@@ -11,7 +11,7 @@ class UserNode(DjangoObjectType):
     class Meta:
         model = get_user_model()
         filter_fields = app_settings.USER_NODE_FILTER_FIELDS
-        exclude_fields = app_settings.USER_NODE_EXCLUDE_FIELDS
+        exclude = app_settings.USER_NODE_EXCLUDE_FIELDS
         interfaces = (graphene.relay.Node,)
 
     pk = graphene.Int()


### PR DESCRIPTION
The library is using the outdated `exclude_field` this is replaced by the `exclude` property.

https://github.com/graphql-python/graphene-django/blob/master/graphene_django/types.py#L148