### PR TITLE
Feature/async email support

### DIFF
--- a/graphql_auth/mixins.py
+++ b/graphql_auth/mixins.py
@@ -34,9 +34,9 @@ from .decorators import (
 )
 
 UserModel = get_user_model()
-try:
+if app_settings.EMAIL_ASYNC_TASK and isinstance(app_settings.EMAIL_ASYNC_TASK, str):
     async_email_func = import_string(app_settings.EMAIL_ASYNC_TASK)
-except ImportError:
+else:
     async_email_func = None
 
 

--- a/graphql_auth/mixins.py
+++ b/graphql_auth/mixins.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import SetPasswordForm, PasswordChangeForm
 from django.db import transaction
+from django.utils.module_loading import import_string
 
 import graphene
 
@@ -33,6 +34,10 @@ from .decorators import (
 )
 
 UserModel = get_user_model()
+try:
+    async_email_func = import_string(app_settings.EMAIL_ASYNC_TASK)
+except ImportError:
+    async_email_func = None
 
 
 class RegisterMixin(Output):
@@ -85,7 +90,11 @@ class RegisterMixin(Output):
                         app_settings.SEND_ACTIVATION_EMAIL is True and email
                     )
                     if send_activation:
-                        user.status.send_activation_email(info)
+                        # TODO CHECK FOR EMAIL ASYNC SETTING
+                        if async_email_func:
+                            async_email_func(user.status.send_activation_email, info)
+                        else:
+                            user.status.send_activation_email(info)
                     if app_settings.ALLOW_LOGIN_NOT_VERIFIED:
                         payload = cls.login_on_register(
                             root, info, password=kwargs.get("password1"), **kwargs
@@ -184,7 +193,10 @@ class ResendActivationEmailMixin(Output):
             f = EmailForm({"email": email})
             if f.is_valid():
                 user = get_user_by_email(email)
-                user.status.resend_activation_email(info)
+                if async_email_func:
+                    async_email_func(user.status.resend_activation_email, info)
+                else:
+                    user.status.resend_activation_email(info)
                 return cls(success=True)
             return cls(success=False, errors=f.errors.get_json_data())
         except ObjectDoesNotExist:
@@ -215,7 +227,12 @@ class SendPasswordResetEmailMixin(Output):
             f = EmailForm({"email": email})
             if f.is_valid():
                 user = get_user_by_email(email)
-                user.status.send_password_reset_email(info, [email])
+                if async_email_func:
+                    async_email_func(
+                        user.status.send_password_reset_email, (info, [email])
+                    )
+                else:
+                    user.status.send_password_reset_email(info, [email])
                 return cls(success=True)
             return cls(success=False, errors=f.errors.get_json_data())
         except ObjectDoesNotExist:
@@ -224,14 +241,17 @@ class SendPasswordResetEmailMixin(Output):
             return cls(success=False, errors=Messages.EMAIL_FAIL)
         except UserNotVerified:
             user = get_user_by_email(email)
-            try:
-                user.status.resend_activation_email(info)
-                return cls(
-                    success=False,
-                    errors={"email": Messages.NOT_VERIFIED_PASSWORD_RESET},
-                )
-            except SMTPException:
-                return cls(success=False, errors=Messages.EMAIL_FAIL)
+            if async_email_func:
+                async_email_func(user.status.resend_activation_email, info)
+            else:
+                try:
+                    user.status.resend_activation_email(info)
+                    return cls(
+                        success=False,
+                        errors={"email": Messages.NOT_VERIFIED_PASSWORD_RESET},
+                    )
+                except SMTPException:
+                    return cls(success=False, errors=Messages.EMAIL_FAIL)
 
 
 class PasswordResetMixin(Output):
@@ -476,7 +496,12 @@ class SendSecondaryEmailActivationMixin(Output):
             f = EmailForm({"email": email})
             if f.is_valid():
                 user = info.context.user
-                user.status.send_secondary_email_activation(info, email)
+                if async_email_func:
+                    async_email_func(
+                        user.status.send_secondary_email_activation, (info, email)
+                    )
+                else:
+                    user.status.send_secondary_email_activation(info, email)
                 return cls(success=True)
             return cls(success=False, errors=f.errors.get_json_data())
         except EmailAlreadyInUse:

--- a/graphql_auth/settings.py
+++ b/graphql_auth/settings.py
@@ -64,7 +64,7 @@ DEFAULTS = {
     },
     # turn is_active to False instead
     "ALLOW_DELETE_ACCOUNT": False,
-    "EMAIL_ASYNC_TASK" : False,
+    "EMAIL_ASYNC_TASK": False,
 }
 
 

--- a/graphql_auth/settings.py
+++ b/graphql_auth/settings.py
@@ -64,6 +64,7 @@ DEFAULTS = {
     },
     # turn is_active to False instead
     "ALLOW_DELETE_ACCOUNT": False,
+    "EMAIL_ASYNC_TASK" : False,
 }
 
 


### PR DESCRIPTION
This PR follows the guides from https://github.com/PedroBern/django-graphql-auth/issues/11
Adds `ASYNC_EMAIL_TASK` setting to settings. 

In `mixins.py` first, if `ASYNC_EMAIL_TASK` setting is defined and it's a string, will be imported in top.
Then before sending each email, first it's checked if the async function is defined and if it is, call the function with the email send function and it's arguments, else just send the email. 

This is done for:
1. Send activation email
1. Resend Activation Email
1. Password reset
1. Secondary email activation

Right now when I run tests, there's no test case for async functions, so either a test case needs to be provided, or we need to add async email support in the example app. 

@PedroBern please review and let me know what you think. 