### PR TITLE
Add select_related to UserNode to limit unnecessary db queries

### DIFF
--- a/graphql_auth/schema.py
+++ b/graphql_auth/schema.py
@@ -32,6 +32,10 @@ class UserNode(DjangoObjectType):
     def resolve_secondary_email(self, info):
         return self.status.secondary_email
 
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        return queryset.select_related("status")
+
 
 class UserQuery(graphene.ObjectType):
     user = graphene.relay.Node.Field(UserNode)


### PR DESCRIPTION
Selecting users with fields from status (`UserStatus`) results in an additional db query per user which will impact performance when selecting large numbers of users. By adding `select_related` to `UserNode.get_queryset` the status table results are included in a single db query.

This will have the slight detrimental impact of a more complex unnecessary query when the `status` fields are not needed / used. In principle it may be possible to determine when the `select_related` is needed (e.g. based on what fields are included). This is beyond my knowledge of what is available from graphene, but happy to have a go if you have a suggestion.