### PR TITLE
Fix Authentication Backend Link

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -200,7 +200,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 ```
 
-[Here](/installation/#3-authentication-backend-optional) is an explanation why we are adding this backend.
+[Here](installation.md#3-authentication-backend-optional) is an explanation why we are adding this backend.
 
 And make sure your templates configuration has the following:
 


### PR DESCRIPTION
The authentication backend link on https://django-graphql-auth.readthedocs.io/en/latest/quickstart/#install-django-graphql-auth was broken