### PR TITLE
Add custom variables to email template settings

### DIFF
--- a/docs/overriding-email-templates.md
+++ b/docs/overriding-email-templates.md
@@ -56,6 +56,7 @@ Both subject and email templates receive the following variables:
 - path --> defined in [settings](settings.md) <small>(some frontend path)</small>
 - request
 - timestamp
+- custom variables defined using EMAIL_TEMPLATE_VARIABLES setting --> defined in [settings](settings.md)
 
 
 ## Writing the templates

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -260,3 +260,28 @@ default: `#!python "email/activation_email.html"`
 ### EMAIL_TEMPLATE_PASSWORD_RESET
 
 default: `#!python "email/password_reset_email.html"`
+
+### EMAIL_TEMPLATE_VARIABLES
+
+default: `#!python {}`
+
+Dictionary of key value pairs of template variables that will be injected into the templates.
+
+Example:
+
+```python
+GRAPHQL_AUTH = {
+    "EMAIL_TEMPLATE_VARIABLES": {
+        "frontend_domain": "the-frontend.com"
+    }
+}
+```
+
+Now, in the templates:
+{% raw %}
+
+```html
+<p>{{ protocol }}://{{ frontend_domain }}/{{ path }}/{{ token }}</p>
+```
+
+{% endraw %}

--- a/graphql_auth/models.py
+++ b/graphql_auth/models.py
@@ -66,6 +66,7 @@ class UserStatus(models.Model):
             "protocol": "https" if info.context.is_secure() else "http",
             "path": path,
             "timestamp": time.time(),
+            **app_settings.EMAIL_TEMPLATE_VARIABLES,
         }
 
     def send_activation_email(self, info, *args, **kwargs):

--- a/graphql_auth/settings.py
+++ b/graphql_auth/settings.py
@@ -52,6 +52,7 @@ DEFAULTS = {
     "EMAIL_TEMPLATE_ACTIVATION_RESEND": "email/activation_email.html",
     "EMAIL_TEMPLATE_SECONDARY_EMAIL_ACTIVATION": "email/activation_email.html",
     "EMAIL_TEMPLATE_PASSWORD_RESET": "email/password_reset_email.html",
+    "EMAIL_TEMPLATE_VARIABLES": {},
     # query stuff
     "USER_NODE_EXCLUDE_FIELDS": ["password", "is_superuser"],
     "USER_NODE_FILTER_FIELDS": {


### PR DESCRIPTION
Solves #22 

I've just added the EMAIL_TEMPLATE_VARIABLES that allows us to define custom variables and use them in any template.

The default of the variable is a empty dict (`{}`). 

The only problem that may occur with my implementation is if we define a custom variable with the same name of an existing variable, such as `user`, `token`, `path`, etc. This definition will override the original variable. If this represents a issue to the project, we could change how the custom variables are injected to templates, maybe injecting a `variables` key in the dict that are used to access the defined variables.


Also, I didn't know how to test this settings, so I only tested it with the `testproject`, changing the activation template and registering a user. Let me know if there's a way to add a test for it and I'll do :D


Example:

```python
GRAPHQL_AUTH = {
    "EMAIL_TEMPLATE_VARIABLES": {
        "frontend_domain": "my-frontend-domain.com"
    }
}
```

Now, in the templates:

```html
<p>{{ protocol }}://{{ frontend_domain }}/{{ path }}/{{ token }}</p>
```


Result:

![image](https://user-images.githubusercontent.com/4624073/95682880-44bf1f80-0bbe-11eb-9aa9-6cbb6868b7e5.png)



