### PR TITLE
Verify user in password reset mutation

### DIFF
--- a/docs/data/api.yml
+++ b/docs/data/api.yml
@@ -70,6 +70,8 @@ PasswordReset: |
     If token and new passwords are valid, update
     user password and in case of using refresh
     tokens, revoke all of them.
+
+    Also, if user has not been verified yet, verify it.
     
 ObtainJSONWebToken: |
     Obtain JSON web token for given user.

--- a/graphql_auth/mixins.py
+++ b/graphql_auth/mixins.py
@@ -263,6 +263,8 @@ class PasswordResetMixin(Output):
     If token and new passwords are valid, update
     user password and in case of using refresh
     tokens, revoke all of them.
+
+    Also, if user has not been verified yet, verify it.
     """
 
     form = SetPasswordForm
@@ -281,6 +283,11 @@ class PasswordResetMixin(Output):
             if f.is_valid():
                 revoke_user_refresh_token(user)
                 user = f.save()
+
+                if user.status.verified is False:
+                    user.status.verified = True
+                    user.status.save(update_fields=["verified"])
+
                 return cls(success=True)
             return cls(success=False, errors=f.errors.get_json_data())
         except SignatureExpired:

--- a/graphql_auth/models.py
+++ b/graphql_auth/models.py
@@ -88,8 +88,6 @@ class UserStatus(models.Model):
         return self.send(subject, template, email_context, *args, **kwargs)
 
     def send_password_reset_email(self, info, *args, **kwargs):
-        if self.verified is False:
-            raise UserNotVerified
         email_context = self.get_email_context(
             info, app_settings.PASSWORD_RESET_PATH_ON_EMAIL, TokenAction.PASSWORD_RESET
         )

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -55,6 +55,20 @@ class PasswordResetTestCaseMixin:
         for token in refresh_tokens:
             self.assertTrue(token.revoked)
 
+    def test_reset_password_verify_user(self):
+        self.user1.verified = False
+        self.user1.save()
+
+        token = get_token(self.user1, "password_reset")
+        query = self.get_query(token)
+        executed = self.make_request(query)
+
+        self.assertEqual(executed["success"], True)
+        self.assertEqual(executed["errors"], None)
+        self.user1.refresh_from_db()
+        self.assertFalse(self.user1_old_pass == self.user1.password)
+        self.assertTrue(self.user1.status.verified)
+
 
 class PasswordResetTestCase(PasswordResetTestCaseMixin, DefaultTestCase):
     def get_login_query(self):

--- a/tests/test_send_password_reset_email.py
+++ b/tests/test_send_password_reset_email.py
@@ -35,24 +35,6 @@ class SendPasswordResetEmailTestCaseMixin:
         self.assertEqual(executed["success"], False)
         self.assertTrue(executed["errors"]["email"])
 
-    def test_send_email_to_not_verified_user(self):
-        query = self.get_query("foo@email.com")
-        executed = self.make_request(query)
-        self.assertEqual(executed["success"], False)
-        self.assertEqual(
-            executed["errors"]["email"], Messages.NOT_VERIFIED_PASSWORD_RESET
-        )
-
-    @mock.patch(
-        "graphql_auth.models.UserStatus.resend_activation_email",
-        mock.MagicMock(side_effect=SMTPException),
-    )
-    def test_send_email_to_not_verified_user_emal_fail(self):
-        query = self.get_query("foo@email.com")
-        executed = self.make_request(query)
-        self.assertEqual(executed["success"], False)
-        self.assertEqual(executed["errors"]["nonFieldErrors"], Messages.EMAIL_FAIL)
-
     def test_send_email_valid_email_verified_user(self):
         query = self.get_query("bar@email.com")
         executed = self.make_request(query)


### PR DESCRIPTION
Solves #52 

When a not verified user is reseting a password, verify it, once the user has already used its own email to receive the reset token.

I've also removed the check for verified user in `send_password_reset_email`. 