### PR TITLE
 Installation: PyJWT v1.7.1

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,7 @@
 ## Installation
 
 ```bash
+pip install pyjwt==1.7.1
 pip install django-graphql-auth
 ```
 


### PR DESCRIPTION
`django-graphql-jwt v0.3.0` isn't compatible with `PyJWT v2.0` but automatically installs it.  We need to install `PyJWT v1.7.1` manually before `django-graphql-auth`

https://github.com/flavors/django-graphql-jwt/issues/242