### PR TITLE
Update dependencies: PyJWT and django-graphql-jwt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "Django>=2.2.0",
-        "django-graphql-jwt==0.3.0",
+        "django-graphql-jwt==0.3.2",
         "django-filter>=2.2.0",
         "graphene_django>=2.1.8",
         "graphene>=2.1.8",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         "django-filter>=2.2.0",
         "graphene_django>=2.1.8",
         "graphene>=2.1.8",
-        "PyJWT<2.0.0",
     ],
     tests_require=tests_require,
     classifiers=[


### PR DESCRIPTION
Currently other JWT libraries that used with django-graphql require PyJWT > 2.0, e.g: django-graphql-jwt

Remove PyJWT from the dependencies from django-graphsql-auth is safe because this isn't imported directly here.

Upgraded django-graphql-jwt from 0.3.0 to 0.3.2.

I've run the following tests locally:

```bash
$ make test
...
  py38-django30: commands succeeded
  congratulations :)
```

Lint and format run locally too.