### PR TITLE
Fix typo in function get_token_payload

### DIFF
--- a/graphql_auth/mixins.py
+++ b/graphql_auth/mixins.py
@@ -26,7 +26,7 @@ from .exceptions import (
     PasswordAlreadySetError,
 )
 from .constants import Messages, TokenAction
-from .utils import revoke_user_refresh_token, get_token_paylod, using_refresh_tokens
+from .utils import revoke_user_refresh_token, get_token_payload, using_refresh_tokens
 from .shortcuts import get_user_by_email, get_user_to_login
 from .signals import user_registered, user_verified
 from .decorators import (
@@ -296,7 +296,7 @@ class PasswordResetMixin(Output):
     def resolve_mutation(cls, root, info, **kwargs):
         try:
             token = kwargs.pop("token")
-            payload = get_token_paylod(
+            payload = get_token_payload(
                 token,
                 TokenAction.PASSWORD_RESET,
                 app_settings.EXPIRATION_PASSWORD_RESET_TOKEN,
@@ -339,7 +339,7 @@ class PasswordSetMixin(Output):
     def resolve_mutation(cls, root, info, **kwargs):
         try:
             token = kwargs.pop("token")
-            payload = get_token_paylod(
+            payload = get_token_payload(
                 token,
                 TokenAction.PASSWORD_SET,
                 app_settings.EXPIRATION_PASSWORD_SET_TOKEN,

--- a/graphql_auth/models.py
+++ b/graphql_auth/models.py
@@ -11,7 +11,7 @@ from django.db import transaction
 
 from .settings import graphql_auth_settings as app_settings
 from .constants import TokenAction
-from .utils import get_token, get_token_paylod
+from .utils import get_token, get_token_payload
 from .exceptions import (
     UserAlreadyVerified,
     UserNotVerified,
@@ -139,7 +139,7 @@ class UserStatus(models.Model):
 
     @classmethod
     def verify(cls, token):
-        payload = get_token_paylod(
+        payload = get_token_payload(
             token, TokenAction.ACTIVATION, app_settings.EXPIRATION_ACTIVATION_TOKEN
         )
         user = UserModel._default_manager.get(**payload)
@@ -153,7 +153,7 @@ class UserStatus(models.Model):
 
     @classmethod
     def verify_secondary_email(cls, token):
-        payload = get_token_paylod(
+        payload = get_token_payload(
             token,
             TokenAction.ACTIVATION_SECONDARY_EMAIL,
             app_settings.EXPIRATION_SECONDARY_EMAIL_ACTIVATION_TOKEN,

--- a/graphql_auth/utils.py
+++ b/graphql_auth/utils.py
@@ -1,9 +1,11 @@
+import warnings
 from django.core import signing
 from django.contrib.auth import get_user_model
 from django.conf import settings as django_settings
 from django.core.signing import BadSignature
 
 from .exceptions import TokenScopeError
+warnings.simplefilter("once")
 
 
 def get_token(user, action, **kwargs):
@@ -17,12 +19,17 @@ def get_token(user, action, **kwargs):
     return token
 
 
-def get_token_paylod(token, action, exp=None):
+def get_token_payload(token, action, exp=None):
     payload = signing.loads(token, max_age=exp)
     _action = payload.pop("action")
     if _action != action:
         raise TokenScopeError
     return payload
+
+
+def get_token_paylod(token, action, exp=None):
+    warnings.warn("get_token_paylod is deprecated, use get_token_payload instead", DeprecationWarning, stacklevel=2)
+    return get_token_payload(token, action, exp)
 
 
 def using_refresh_tokens():

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -6,7 +6,7 @@ from .testCases import RelayTestCase, DefaultTestCase
 
 from graphql_auth.utils import revoke_user_refresh_token
 from graphql_auth.constants import Messages
-from graphql_auth.utils import get_token, get_token_paylod
+from graphql_auth.utils import get_token, get_token_payload
 
 
 class PasswordChangeTestCaseMixin:

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 
 from .testCases import RelayTestCase, DefaultTestCase
 from graphql_auth.constants import Messages
-from graphql_auth.utils import get_token, get_token_paylod
+from graphql_auth.utils import get_token, get_token_payload
 
 
 class PasswordResetTestCaseMixin:

--- a/tests/test_password_set.py
+++ b/tests/test_password_set.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 
 from .testCases import RelayTestCase, DefaultTestCase
 from graphql_auth.constants import Messages
-from graphql_auth.utils import get_token, get_token_paylod
+from graphql_auth.utils import get_token, get_token_payload
 
 
 class PasswordSetTestCaseMixin:

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -10,7 +10,7 @@ from .decorators import skipif_django_21
 
 from graphql_auth.constants import Messages
 from graphql_auth.signals import user_registered
-from graphql_auth.utils import get_token, get_token_paylod
+from graphql_auth.utils import get_token, get_token_payload
 
 
 class RegisterTestCaseMixin:

--- a/tests/test_verify_account.py
+++ b/tests/test_verify_account.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 
 from .testCases import RelayTestCase, DefaultTestCase
 from graphql_auth.constants import Messages
-from graphql_auth.utils import get_token, get_token_paylod
+from graphql_auth.utils import get_token, get_token_payload
 from graphql_auth.models import UserStatus
 from graphql_auth.signals import user_verified
 


### PR DESCRIPTION
This changes the function name from `get_token_paylod` to `get_token_payload`.

I added another function `get_token_paylod` with a deprecation warning (it warns only once if called multiple times) which simply calls and returns the result of `get_token_payload`.

Alternatively one could assign `get_token_paylod = get_token_payload` but this wouldn't trigger a deprecation warning.