### PR TITLE
Fix UpdateAccount to accept optional arguments for partial updates

### DIFF
--- a/graphql_auth/forms.py
+++ b/graphql_auth/forms.py
@@ -28,6 +28,11 @@ class UpdateAccountForm(UserChangeForm):
         fields = flat_dict(app_settings.UPDATE_MUTATION_FIELDS)
         field_classes = {"username": CustomUsernameField}
 
+    def __init__(self, *args, **kwargs):
+        super(UpdateAccountForm, self).__init__(*args, **kwargs)
+        for key, field in self.fields.items():
+            self.fields[key].required = False
+
 
 class PasswordLessRegisterForm(UserCreationForm):
     """

--- a/graphql_auth/mixins.py
+++ b/graphql_auth/mixins.py
@@ -535,6 +535,10 @@ class UpdateAccountMixin(Output):
     @verification_required
     def resolve_mutation(cls, root, info, **kwargs):
         user = info.context.user
+        fields = cls.form.Meta.fields
+        for field in fields:
+            if field not in kwargs:
+                kwargs[field] = getattr(user, field)
         f = cls.form(kwargs, instance=user)
         if f.is_valid():
             f.save()

--- a/graphql_auth/utils.py
+++ b/graphql_auth/utils.py
@@ -5,6 +5,7 @@ from django.conf import settings as django_settings
 from django.core.signing import BadSignature
 
 from .exceptions import TokenScopeError
+
 warnings.simplefilter("once")
 
 
@@ -28,7 +29,11 @@ def get_token_payload(token, action, exp=None):
 
 
 def get_token_paylod(token, action, exp=None):
-    warnings.warn("get_token_paylod is deprecated, use get_token_payload instead", DeprecationWarning, stacklevel=2)
+    warnings.warn(
+        "get_token_paylod is deprecated, use get_token_payload instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return get_token_payload(token, action, exp)
 
 


### PR DESCRIPTION
This fixes issue    #69 .

The inputs are first made optional by setting ``required = False``. This causes an overwrite of the previous state of the account. In order to update only the inputs being passed from the mutation, the current values are appended in the mixin as kwargs before saving