### PR TITLE
Clarify documentation regarding setup

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -190,7 +190,8 @@ AUTHENTICATION_BACKENDS = [
     # add this
     "graphql_auth.backends.GraphQLAuthBackend",
 
-    # ...
+    # if you have no more authentication backends defined besides graphql_auth.backends.GraphQLAuthBackend, add this
+    "django.contrib.auth.backends.ModelBackend"  
 ]
 ```
 


### PR DESCRIPTION
There is some confusion caused by the AUTHENTICATION_BACKENDS setup instructions from the documentation, which when not set properly, it will cause confusing errors to appear which are not related to the error source.

Example of such confusion:
- https://github.com/PedroBern/django-graphql-auth/issues/126